### PR TITLE
Use a special prefix for env vars and add a dash replacer for flags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -46,6 +47,10 @@ func Execute() {
 }
 
 func init() {
+	replacer := strings.NewReplacer("-", "_")
+	viper.SetEnvKeyReplacer(replacer)
+	viper.SetEnvPrefix("shipyard")
+	viper.AutomaticEnv()
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.shipyard/config.yaml)")
@@ -79,8 +84,6 @@ func setupCommands() {
 }
 
 func initConfig() {
-	viper.AutomaticEnv()
-
 	if cfgFile != "" {
 		viper.SetConfigFile(cfgFile)
 		if err := viper.ReadInConfig(); err != nil {


### PR DESCRIPTION
This does two things:
1. Make Viper look for environment variables that match flag names. Values must start with the special prefix SHIPYARD followed by the flag name also in uppercase. Words are delimited by underscores. For example, for a flag `--name`, Viper will look for a corresponding env var `SHIPYARD_NAME`.
2. Add an env key replacer where Viper looks for flags that have dashes and transforms them to env vars that have underscores in place of dashes. For example, for a flag `--repo-name`, Viper will look for a corresponding env var `SHIPYARD_REPO_NAME`.