### PR TITLE
Fix API token environment variable lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ A tool to manage Ephemeral Environments on the Shipyard platform.
 
 ## Get Your Token
 
-Set the environment variable `SHIPYARD_API_TOKEN` to your Shipyard API token.
+Set your Shipyard API token as the value of the `SHIPYARD_API_TOKEN` environment variable.
+Or set it as the value for the `api_token` config key.
+
 You can get it by going to [your profile page](https://shipyard.build/profile).
 
 ### Set a Shipyard token

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -9,9 +9,9 @@ import (
 // GetAPIToken tries to read a token for the Shipyard API
 // from the environment variable or loaded config (in that order).
 func GetAPIToken() (string, error) {
-	token := viper.GetString("SHIPYARD_API_TOKEN")
+	token := viper.GetString("API_TOKEN")
 	if token == "" {
-		return "", errors.New("token is missing, set the SHIPYARD_API_TOKEN environment/config value")
+		return "", errors.New("token is missing, set the 'SHIPYARD_API_TOKEN' environment variable or 'api_token' config value")
 	}
 	return token, nil
 }

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -82,7 +82,7 @@ func setTokenInteractively(r io.Reader) error {
 }
 
 func setToken(token string) error {
-	viper.Set("shipyard_api_token", token)
+	viper.Set("api_token", token)
 	err := viper.MergeInConfig()
 	if err != nil {
 		return err

--- a/config/config.go
+++ b/config/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Config struct {
-	Token   string `yaml:"shipyard_api_token"`
+	Token   string `yaml:"api_token"`
 	Org     string `yaml:"org"`
 	Verbose bool   `yaml:"verbose"`
 }


### PR DESCRIPTION
The introduction of automatic environment lookup caused a regression where a `SHIPYARD_API_TOKEN` env var was not found by Viper, because the name of the environment variable when it's **looked up** should be without the leading `SHIPYARD_`.