### PR TITLE
Print a message when a collection of environments is truncated

### DIFF
--- a/commands/env/get.go
+++ b/commands/env/get.go
@@ -2,6 +2,7 @@ package env
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -146,6 +147,9 @@ func handleGetAllEnvironments(c client.Client) error {
 	}
 	columns := []string{"App", "UUID", "Ready", "Repo", "PR#", "URL"}
 	display.RenderTable(os.Stdout, columns, data)
+	if r.Links.Next != "" {
+		display.Println(fmt.Sprintf("Table is truncated, fetch the next page %d.", r.NextPage()))
+	}
 	return nil
 }
 

--- a/pkg/requests/requests.go
+++ b/pkg/requests/requests.go
@@ -83,7 +83,7 @@ func (c HTTPClient) Do(method, uri string, body any) ([]byte, error) {
 		if len(b) == 0 {
 			return nil, fmt.Errorf("empty response")
 		}
-		errString := types.ParseErrorResponse(b)
+		errString := types.ErrorFromResponse(b)
 		if errString == "" {
 			return nil, errors.New(string(b))
 		}

--- a/pkg/types/parse.go
+++ b/pkg/types/parse.go
@@ -73,7 +73,7 @@ type Links struct {
 	Prev  string `json:"prev"`
 }
 
-func ParseErrorResponse(p []byte) string {
+func ErrorFromResponse(p []byte) string {
 	var r errorResponse
 	if err := json.Unmarshal(p, &r); err != nil {
 		return ""

--- a/pkg/types/parse.go
+++ b/pkg/types/parse.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
+	"strconv"
 )
 
 var errUnmarshalling = errors.New("failed to unmarshal a value")
@@ -42,6 +44,18 @@ type RespManyEnvs struct {
 	Data []struct {
 		Environment
 	} `json:"data"`
+	Links Links `json:"links"`
+}
+
+// NextPage extracts the value of the "page" query parameter of the "next" URL.
+func (r RespManyEnvs) NextPage() int {
+	parsed, err := url.Parse(r.Links.Next)
+	if err != nil {
+		return 0
+	}
+	page := parsed.Query().Get("page")
+	i, _ := strconv.Atoi(page)
+	return i
 }
 
 type OrgsResponse struct {
@@ -50,6 +64,13 @@ type OrgsResponse struct {
 			Name string `json:"name"`
 		} `json:"attributes"`
 	} `json:"data"`
+}
+
+type Links struct {
+	First string `json:"first"`
+	Last  string `json:"last"`
+	Next  string `json:"next"`
+	Prev  string `json:"prev"`
 }
 
 func ParseErrorResponse(p []byte) string {

--- a/pkg/types/parse_test.go
+++ b/pkg/types/parse_test.go
@@ -1,6 +1,55 @@
 package types
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNextPage(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{
+			name:  "empty url",
+			input: "",
+			want:  0,
+		},
+		{
+			name:  "page query parameter missing",
+			input: "/api/v1/environment?page_size=20",
+			want:  0,
+		},
+		{
+			name:  "bad value for page",
+			input: "/api/v1/environment?page=2i",
+			want:  0,
+		},
+		{
+			name:  "valid url",
+			input: "/api/v1/environment?page=2&page_size=5",
+			want:  2,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			r := RespManyEnvs{
+				Links: Links{
+					Next: test.input,
+				},
+			}
+			if got := r.NextPage(); got != test.want {
+				t.Errorf(cmp.Diff(got, test.want))
+			}
+		})
+	}
+}
 
 func TestParseErrorResponse(t *testing.T) {
 	t.Parallel()

--- a/pkg/types/parse_test.go
+++ b/pkg/types/parse_test.go
@@ -51,65 +51,78 @@ func TestNextPage(t *testing.T) {
 	}
 }
 
-func TestParseErrorResponse(t *testing.T) {
+func TestErrorFromResponse(t *testing.T) {
 	t.Parallel()
-
 	tests := []struct {
+		name string
 		resp []byte
 		want string
 	}{
 		{
+			name: "nil response",
 			resp: nil,
 			want: "",
 		},
 		{
+			name: "empty response",
 			resp: []byte{},
 			want: "",
 		},
 		{
+			name: "valid response without error",
 			resp: []byte(
 				`{
-				    "attributes": {
-				     	"name": "foo"
-				    },
-				    "id": "1234",
-				    "type": "org"
-    			}`,
+                    "attributes": {
+                        "name": "foo"
+                    },
+                    "id": "1234",
+                    "type": "org"
+                }`,
 			),
 			want: "",
 		},
 		{
+			name: "valid response containing an error",
 			resp: []byte(
 				`{
-					"errors": [
-					    {
-					     	"status": 404,
-					     	"title": "Environment not found"
-					    }
-					]
-				}`,
+                    "errors": [
+                        {
+                            "status": 404,
+                            "title": "Environment not found"
+                        }
+                    ]
+                }`,
 			),
 			want: "Environment not found",
 		},
 		{
+			name: "valid response containing multiple errors",
 			resp: []byte(
 				`{
-					"errors": [
-					    {
-					     	"status": 404,
-					        "title": "User org not found"
-					    }
-					]
-				}`,
+                    "errors": [
+                        {
+                            "status": 404,
+                            "title": "Environment not found"
+                        },
+						{
+                            "status": 418,
+                            "title": "I am a teapot"
+                        }
+                    ]
+                }`,
 			),
-			want: "User org not found",
+			want: "Environment not found",
 		},
 	}
 
 	for _, test := range tests {
-		got := ParseErrorResponse(test.resp)
-		if got != test.want {
-			t.Errorf("want %s, but got %s", test.want, got)
-		}
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := ErrorFromResponse(test.resp)
+			if got != test.want {
+				t.Errorf(cmp.Diff(got, test.want))
+			}
+		})
 	}
 }


### PR DESCRIPTION
When `shipyard get environments` returns more results than a page can fit, the CLI displays a message:
`Table is truncated, fetch the next page {n}.` It gives the user the number of the next page.

Also adjusted the tests of error response parsing logic.