### PR TITLE
Add a login command

### DIFF
--- a/commands/login.go
+++ b/commands/login.go
@@ -1,0 +1,89 @@
+package commands
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+
+	"github.com/shipyard/shipyard-cli/auth"
+	"github.com/shipyard/shipyard-cli/pkg/display"
+)
+
+func NewLoginCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:          "login",
+		Short:        "Log in to the CLI",
+		Long:         "This command opens a web browser, prompts you to log in to Shipyard, and saves a new API token in your local config file",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return login()
+		},
+	}
+}
+
+func login() error {
+	if _, err := auth.GetAPIToken(); err == nil {
+		display.Println("You are already logged in.")
+		return nil
+	}
+
+	tokenChan := make(chan string)
+	errChan := make(chan error)
+	mux := http.NewServeMux()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t := r.URL.Query().Get("token")
+		if t == "" {
+			errChan <- fmt.Errorf("no token received from Shipyard")
+			return
+		}
+		tokenChan <- t
+		fmt.Fprintln(w, "Authentication succeeded. You may close this browser tab.")
+	})
+	mux.Handle("/", handler)
+
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return fmt.Errorf("error creating a local callback server: %w", err)
+	}
+	listener.Close()
+	port := listener.Addr().(*net.TCPAddr).Port
+	server := &http.Server{
+		Addr:              net.JoinHostPort("localhost", strconv.Itoa(port)),
+		Handler:           mux,
+		ReadHeaderTimeout: 3 * time.Second,
+	}
+
+	go func() {
+		log.Printf("Trying to start a local callback server on %s.", server.Addr)
+		if err := server.ListenAndServe(); err != nil {
+			display.Fail(err)
+			errChan <- err
+			return
+		}
+		log.Println("Shutting down the local server.")
+	}()
+
+	display.Println("Opening the default web browser...")
+	backendURL := fmt.Sprintf("https://shipyard.build/api/me/user-token/cli?callbackUrl=http://%s", server.Addr)
+	if err := browser.OpenURL(backendURL); err != nil {
+		return err
+	}
+	select {
+	case <-time.After(time.Minute):
+		return fmt.Errorf("authentication timeout")
+	case err := <-errChan:
+		return fmt.Errorf("login error: %w", err)
+	case t := <-tokenChan:
+		if err := SetToken(t); err != nil {
+			return err
+		}
+		display.Println("Login succeeded!")
+	}
+	return nil
+}

--- a/commands/root.go
+++ b/commands/root.go
@@ -71,6 +71,7 @@ func setupCommands() {
 	token, _ := auth.GetAPIToken()
 	requester := requests.New(token)
 	c := client.New(requester, viper.GetString("org"))
+	rootCmd.AddCommand(NewLoginCmd())
 	rootCmd.AddCommand(NewGetCmd(c))
 	rootCmd.AddCommand(NewSetCmd())
 

--- a/commands/set.go
+++ b/commands/set.go
@@ -52,7 +52,7 @@ func NewSetTokenCmd() *cobra.Command {
 			if len(args) == 0 {
 				return setTokenInteractively(os.Stdin)
 			}
-			return setToken(args[0])
+			return SetToken(args[0])
 		},
 	}
 
@@ -77,11 +77,13 @@ func setTokenInteractively(r io.Reader) error {
 		return err
 	}
 
-	return setToken(token)
+	return SetToken(token)
 }
 
-func setToken(token string) error {
+func SetToken(token string) error {
 	viper.Set("api_token", token)
+	// TODO: find a better way to not persist the value of verbose globally.
+	viper.Set("verbose", false)
 	err := viper.MergeInConfig()
 	if err != nil {
 		return err


### PR DESCRIPTION
This adds a new `login` command, which opens the default browser that is prompted to navigate to the login flow. Afterward a successful login, the browser receives an API token from the main Shipyard server, which it then forwards to the CLI via a temporary local server that the CLI starts on a random open port. The CLI persists the token in the local config.