### PR TITLE
Make the HTTP client look up the token in Viper when needed

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -6,9 +6,9 @@ import (
 	"github.com/spf13/viper"
 )
 
-// GetAPIToken tries to read a token for the Shipyard API
+// APIToken tries to read a token for the Shipyard API
 // from the environment variable or loaded config (in that order).
-func GetAPIToken() (string, error) {
+func APIToken() (string, error) {
 	token := viper.GetString("API_TOKEN")
 	if token == "" {
 		return "", errors.New("token is missing, set the 'SHIPYARD_API_TOKEN' environment variable or 'api_token' config value")

--- a/commands/login.go
+++ b/commands/login.go
@@ -28,7 +28,7 @@ func NewLoginCmd() *cobra.Command {
 }
 
 func login() error {
-	if _, err := auth.GetAPIToken(); err == nil {
+	if _, err := auth.APIToken(); err == nil {
 		display.Println("You are already logged in.")
 		return nil
 	}

--- a/commands/root.go
+++ b/commands/root.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/viper"
 	"k8s.io/client-go/util/homedir"
 
-	"github.com/shipyard/shipyard-cli/auth"
 	"github.com/shipyard/shipyard-cli/commands/env"
 	"github.com/shipyard/shipyard-cli/commands/k8s"
 	"github.com/shipyard/shipyard-cli/config"
@@ -54,6 +53,7 @@ func init() {
 	viper.SetEnvKeyReplacer(replacer)
 	viper.SetEnvPrefix("shipyard")
 	viper.AutomaticEnv()
+	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.shipyard/config.yaml)")
 
@@ -63,13 +63,11 @@ func init() {
 	rootCmd.PersistentFlags().String("org", "", "Org of environment (default org if unspecified)")
 	_ = viper.BindPFlag("org", rootCmd.PersistentFlags().Lookup("org"))
 
-	initConfig()
 	setupCommands()
 }
 
 func setupCommands() {
-	token, _ := auth.GetAPIToken()
-	requester := requests.New(token)
+	requester := requests.New()
 	c := client.New(requester, viper.GetString("org"))
 	rootCmd.AddCommand(NewLoginCmd())
 	rootCmd.AddCommand(NewGetCmd(c))

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/spf13/viper"
 
 	"github.com/shipyard/shipyard-cli/pkg/requests"
 	"github.com/shipyard/shipyard-cli/pkg/types"
 )
 
-func TestGetByID(t *testing.T) {
+func TestEnvByID(t *testing.T) {
 	t.Parallel()
 
 	client, cleanup := setup()
@@ -71,7 +72,8 @@ func setup() (client Client, cleanup func()) {
 	handler := newMux()
 	server := httptest.NewServer(handler)
 	_ = os.Setenv("SHIPYARD_BUILD_URL", server.URL)
-	c := New(requests.New("someToken"), "")
+	viper.Set("API_TOKEN", "fake-token")
+	c := New(requests.New(), "")
 	return c, func() {
 		defer server.Close()
 	}


### PR DESCRIPTION
This fixes the issue where the CLI ignores a custom config (passed in via the `config` flag).
The problem was with the CLI config and command initialization process.

The fix is to bring back previously used logic where the config is parsed on command pre-run (`cobra.OnInitialize(initConfig)` run in `init`). 
The commands are setup before the CLI looks up the config. And the command setup relies on the config being parsed first.
An immediate fix is to keep the same order (there are difficulties with it now) but not rely on the config being ready during command setup. Instead, make the HTTP client look up the token (which might come from the config) later, when needed.