### PR TITLE
Display names of volumes in the table

### DIFF
--- a/commands/volumes/volumes.go
+++ b/commands/volumes/volumes.go
@@ -55,19 +55,19 @@ func handleGetVolumesCmd(c client.Client) error {
 	if err := json.Unmarshal(body, &resp); err != nil {
 		return fmt.Errorf("failed to unmarshal volumes: %w", err)
 	}
-
-	if err != nil {
-		return err
+	if len(resp.Data) == 0 {
+		display.Println("No volumes found in the environment.")
+		return nil
 	}
+
 	var data [][]string
 	for _, v := range resp.Data {
 		data = append(data, []string{
+			v.Attributes.Name,
 			v.Attributes.ServiceName,
-			v.Attributes.VolumePath,
-			v.Type,
 		})
 	}
-	columns := []string{"Name", "Path", "Type"}
+	columns := []string{"Name", "Service"}
 	display.RenderTable(os.Stdout, columns, data)
 	return nil
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -28,6 +28,7 @@ type Volume struct {
 	Attributes struct {
 		ComposePath      string `json:"compose_path"`
 		RemoteComposeURL string `json:"remote_compose_url"`
+		Name             string `json:"volume_name"`
 		ServiceName      string `json:"service_name"`
 		VolumePath       string `json:"volume_path"`
 	} `json:"attributes"`


### PR DESCRIPTION
If the environment has no volumes, the CLI displays a message instead of an empty table:
```bash
s get volumes --env=abcde
No volumes found in the environment.
```

Standard output for an environment with one or more volumes:
```bash
s get volumes --env=123xyz
  NAME    SERVICE  
-------------------
  dbdata  backend  

```