### PR TITLE
Defer looking up an org using a function for the main client

### DIFF
--- a/commands/env/cancel.go
+++ b/commands/env/cancel.go
@@ -47,8 +47,8 @@ func newCancelEnvironmentCmd(c client.Client) *cobra.Command {
 
 func cancelEnvironmentByID(c client.Client, id string) error {
 	params := make(map[string]string)
-	if c.Org != "" {
-		params["org"] = c.Org
+	if org := c.OrgLookupFn(); org != "" {
+		params["org"] = org
 	}
 	_, err := c.Requester.Do(http.MethodPost, uri.CreateResourceURI("cancel", "environment", id, "", params), "application/json", nil)
 	if err != nil {

--- a/commands/env/get.go
+++ b/commands/env/get.go
@@ -124,7 +124,7 @@ func handleGetAllEnvironments(c client.Client) error {
 	if pageSize := viper.GetInt("page-size"); pageSize != 0 {
 		params["page_size"] = strconv.Itoa(pageSize)
 	}
-	if org := viper.GetString("org"); org != "" {
+	if org := c.OrgLookupFn(); org != "" {
 		params["org"] = org
 	}
 
@@ -161,8 +161,8 @@ func handleGetAllEnvironments(c client.Client) error {
 
 func handleGetEnvironmentByID(c client.Client, id string) error {
 	params := make(map[string]string)
-	if c.Org != "" {
-		params["org"] = c.Org
+	if org := c.OrgLookupFn(); org != "" {
+		params["org"] = org
 	}
 
 	body, err := c.Requester.Do(http.MethodGet, uri.CreateResourceURI("", "environment", id, "", params), "application/json", nil)

--- a/commands/env/rebuild.go
+++ b/commands/env/rebuild.go
@@ -49,8 +49,8 @@ Rebuild will automatically fetch the latest commit for the branch/PR.`,
 
 func rebuildEnvironmentByID(c client.Client, id string) error {
 	params := make(map[string]string)
-	if c.Org != "" {
-		params["org"] = c.Org
+	if org := c.OrgLookupFn(); org != "" {
+		params["org"] = org
 	}
 
 	_, err := c.Requester.Do(http.MethodPost, uri.CreateResourceURI("rebuild", "environment", id, "", params), "application/json", nil)

--- a/commands/env/restart.go
+++ b/commands/env/restart.go
@@ -46,8 +46,8 @@ func newRestartEnvironmentCmd(c client.Client) *cobra.Command {
 
 func restartEnvironmentByID(c client.Client, id string) error {
 	params := make(map[string]string)
-	if c.Org != "" {
-		params["org"] = c.Org
+	if org := c.OrgLookupFn(); org != "" {
+		params["org"] = org
 	}
 
 	_, err := c.Requester.Do(http.MethodPost, uri.CreateResourceURI("restart", "environment", id, "", params), "application/json", nil)

--- a/commands/env/revive.go
+++ b/commands/env/revive.go
@@ -48,8 +48,8 @@ func newReviveEnvironmentCmd(c client.Client) *cobra.Command {
 
 func reviveEnvironmentByID(c client.Client, id string) error {
 	params := make(map[string]string)
-	if c.Org != "" {
-		params["org"] = c.Org
+	if org := c.OrgLookupFn(); org != "" {
+		params["org"] = org
 	}
 
 	_, err := c.Requester.Do(http.MethodPost, uri.CreateResourceURI("revive", "environment", id, "", params), "application/json", nil)

--- a/commands/env/stop.go
+++ b/commands/env/stop.go
@@ -47,8 +47,8 @@ func newStopEnvironmentCmd(c client.Client) *cobra.Command {
 
 func stopEnvironmentByID(c client.Client, id string) error {
 	params := make(map[string]string)
-	if c.Org != "" {
-		params["org"] = c.Org
+	if org := c.OrgLookupFn(); org != "" {
+		params["org"] = org
 	}
 
 	_, err := c.Requester.Do(http.MethodPost, uri.CreateResourceURI("stop", "environment", id, "", params), "application/json", nil)

--- a/commands/root.go
+++ b/commands/root.go
@@ -69,7 +69,10 @@ func init() {
 
 func setupCommands() {
 	requester := requests.New()
-	c := client.New(requester, viper.GetString("org"))
+	orgLookupFn := func() string {
+		return viper.GetString("org")
+	}
+	c := client.New(requester, orgLookupFn)
 	rootCmd.AddCommand(NewLoginCmd())
 	rootCmd.AddCommand(NewGetCmd(c))
 	rootCmd.AddCommand(NewSetCmd())

--- a/commands/volumes/create.go
+++ b/commands/volumes/create.go
@@ -42,8 +42,8 @@ func NewCreateSnapshotCmd(c client.Client) *cobra.Command {
 func handleCreateSnapshotCmd(c client.Client) error {
 	envID := viper.GetString("env")
 	params := make(map[string]string)
-	if c.Org != "" {
-		params["Org"] = c.Org
+	if org := c.OrgLookupFn(); org != "" {
+		params["org"] = org
 	}
 	body := map[string]any{
 		"note": viper.GetString("note"),

--- a/commands/volumes/reset.go
+++ b/commands/volumes/reset.go
@@ -45,8 +45,8 @@ func handleResetVolumeCmd(c client.Client) error {
 	envID := viper.GetString("env")
 	volume := viper.GetString("volume")
 	params := make(map[string]string)
-	if c.Org != "" {
-		params["Org"] = c.Org
+	if org := c.OrgLookupFn(); org != "" {
+		params["org"] = org
 	}
 
 	subresource := fmt.Sprintf("volume/%s/volume-reset", volume)

--- a/commands/volumes/snapshots.go
+++ b/commands/volumes/snapshots.go
@@ -42,7 +42,7 @@ func NewGetVolumeSnapshotsCmd(c client.Client) *cobra.Command {
 
 func handleGetVolumeSnapshotsCmd(c client.Client) error {
 	params := make(map[string]string)
-	if org := viper.GetString("org"); org != "" {
+	if org := c.OrgLookupFn(); org != "" {
 		params["org"] = org
 	}
 	if page := viper.GetInt("page"); page != 0 {
@@ -121,7 +121,7 @@ func NewLoadVolumeSnapshotCmd(c client.Client) *cobra.Command {
 
 func handleLoadVolumeSnapshotCmd(c client.Client) error {
 	params := make(map[string]string)
-	if org := viper.GetString("org"); org != "" {
+	if org := c.OrgLookupFn(); org != "" {
 		params["org"] = org
 	}
 	id := viper.GetString("env")

--- a/commands/volumes/upload.go
+++ b/commands/volumes/upload.go
@@ -54,8 +54,8 @@ func handleUploadVolumeCmd(c client.Client) error {
 	envID := viper.GetString("env")
 	volume := viper.GetString("volume")
 	params := make(map[string]string)
-	if c.Org != "" {
-		params["Org"] = c.Org
+	if org := c.OrgLookupFn(); org != "" {
+		params["org"] = org
 	}
 
 	path := viper.GetString("path")

--- a/commands/volumes/volumes.go
+++ b/commands/volumes/volumes.go
@@ -38,8 +38,8 @@ func NewGetVolumesCmd(c client.Client) *cobra.Command {
 func handleGetVolumesCmd(c client.Client) error {
 	id := viper.GetString("env")
 	params := make(map[string]string)
-	if c.Org != "" {
-		params["Org"] = c.Org
+	if org := c.OrgLookupFn(); org != "" {
+		params["org"] = org
 	}
 
 	body, err := c.Requester.Do(http.MethodGet, uri.CreateResourceURI("", "environment", id, "volumes", params), "application/json", nil)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -3,10 +3,10 @@ package client
 import "github.com/shipyard/shipyard-cli/pkg/requests"
 
 type Client struct {
-	Requester requests.Requester
-	Org       string
+	Requester   requests.Requester
+	OrgLookupFn func() string
 }
 
-func New(r requests.Requester, org string) Client {
-	return Client{Requester: r, Org: org}
+func New(r requests.Requester, orgLookupFn func() string) Client {
+	return Client{Requester: r, OrgLookupFn: orgLookupFn}
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -73,7 +73,7 @@ func setup() (client Client, cleanup func()) {
 	server := httptest.NewServer(handler)
 	_ = os.Setenv("SHIPYARD_BUILD_URL", server.URL)
 	viper.Set("API_TOKEN", "fake-token")
-	c := New(requests.New(), "")
+	c := New(requests.New(), func() string { return "" })
 	return c, func() {
 		defer server.Close()
 	}

--- a/pkg/client/env.go
+++ b/pkg/client/env.go
@@ -16,8 +16,8 @@ func (c Client) EnvByID(id string) (*types.Response, error) {
 	}
 
 	params := make(map[string]string)
-	if c.Org != "" {
-		params["Org"] = c.Org
+	if org := c.OrgLookupFn(); org != "" {
+		params["org"] = org
 	}
 
 	body, err := c.Requester.Do(http.MethodGet, uri.CreateResourceURI("", "environment", id, "", params), "application/json", nil)
@@ -31,8 +31,8 @@ func (c Client) EnvByID(id string) (*types.Response, error) {
 // AllEnvironmentUUIDs tries to fetch all environment by UUIDs in an org.
 func (c Client) AllEnvironmentUUIDs() (*types.UUIDResponse, error) {
 	params := make(map[string]string)
-	if c.Org != "" {
-		params["Org"] = c.Org
+	if org := c.OrgLookupFn(); org != "" {
+		params["org"] = org
 	}
 
 	body, err := c.Requester.Do(http.MethodGet, uri.CreateResourceURI("", "environment/uuid", "", "", params), "application/json", nil)

--- a/pkg/k8s/kubeconfig.go
+++ b/pkg/k8s/kubeconfig.go
@@ -28,8 +28,8 @@ func (c *Service) setupKubeconfig(envID string) error {
 // fetchKubeconfig tries to fetch the Kubeconfig from the backend API.
 func (c *Service) fetchKubeconfig(envID string) ([]byte, error) {
 	params := make(map[string]string)
-	if c.client.Org != "" {
-		params["org"] = c.client.Org
+	if org := c.client.OrgLookupFn(); org != "" {
+		params["org"] = org
 	}
 
 	requestURI := uri.CreateResourceURI("", "environment", envID, "kubeconfig", params)


### PR DESCRIPTION
This fixes initialization of the CLI client when it requires an org to be avialable to Viper early.

If I switch my org with `shipyard set org`, the CLI doesn't find the environment in it when I run `shipyard get env [ID]`.
This happens because a call to get the org `viper.GetString("org")` returns an empty string. Viper doesn't yet know the value.

Use a function that determines how the org is looked up. It's deferred this way. Org is such a fundamental thing that we need to know it early, but with the way initialization is set up (perhaps incorrectly), it may not be available to Viper when we need it.