### PR TITLE
Update the goreleaser file and CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: tests
         run: |
-          go test ./... -race -cover
+          go test ./...
 
   lint:
     name: lint

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
 checksum:
   name_template: 'checksums.txt'
 changelog:
-  skip: true
+  disable: true
 brews:
   - name: shipyard
     repository:


### PR DESCRIPTION
- Goreleaser has deprecated `changelog.skip` and asks to use `changelog.disable`
- The tests cannot yet be run with the `-race` flag because there is one that relies on global state