### PR TITLE
Adjust the macOS/Linux installation script to not be silent on errors

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 
 RELEASES_URL="https://github.com/shipyard/shipyard-cli/releases"
 
 last_version() {
-    curl --silent --location --fail \
-    --output /dev/null --write-out %{url_effective} ${RELEASES_URL}/latest |
+    curl --silent --show-error --location --fail \
+        --output /dev/null \
+        --write-out "%{url_effective}" "$RELEASES_URL/latest" |
     grep -Eo '[0-9]+\.[0-9]+\.[0-9]+$'
 }
 
@@ -18,14 +19,15 @@ main() {
         arm64 | aarch64)    ARCH="arm64" ;;
     esac
 
-    [[ -z "$ARCH" ]] && { echo "Platform not supported. Please contact support." ; exit 1; }
+    [[ -z "$ARCH" ]] && { echo "Platform not supported."; exit 1; }
 
     VERSION="$(last_version)"
-    echo "Downloading latest binary..."
+    echo "Downloading the latest binary..."
     URL="${RELEASES_URL}/download/v${VERSION}/shipyard-$(uname -s)-${ARCH}"
     
-    curl --silent -L --output "${default_dir}/shipyard" --fail "$URL"
-    chmod +x ${default_dir}/shipyard
+    curl --silent --show-error --location --fail --output "${PWD}/shipyard" "$URL"
+    chmod +x shipyard
+    sudo mv shipyard "$default_dir"
     echo "Installation Complete! Run 'shipyard --help' to get started."
 }
 


### PR DESCRIPTION
This makes the following adjustments to the script:
- it now runs in debug mode with `x`, so users can see what it does immediately
- it now moves the downloaded binary in a separate step with `sudo`
 - curl reports errors
- shellcheck has no more errors or warnings

Tested on macOS arm64 and Linux amd64.